### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Contributors
    :target: https://codeclimate.com/github/adilansari/python-scribe-logger
 .. |Coverage Status| image:: https://coveralls.io/repos/adilansari/python-scribe-logger/badge.svg?branch=master
    :target: https://coveralls.io/r/adilansari/python-scribe-logger?branch=master
-.. |Supported Python versions| image:: https://pypip.in/py_versions/scribe_logger/badge.svg
+.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/scribe_logger.svg
    :target: https://pypi.python.org/pypi/scribe_logger/
 .. |License| image:: https://img.shields.io/github/license/adilansari/python-scribe-logger.svg
    :target: https://github.com/adilansari/python-scribe-logger/blob/master/LICENSE.mkd


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20scribe-logger))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `scribe-logger`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.